### PR TITLE
feat(command): Add current pull request retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,14 @@
         "title": "PR Agent: Next Pull Request Link Markdown"
       },
       {
+        "command": "pr-agent.currentPullNumber",
+        "title": "PR Agent: Current Pull Request Number"
+      },
+      {
+        "command": "pr-agent.currentPullLink",
+        "title": "PR Agent: Current Pull Request Link Markdown"
+      },
+      {
         "command": "pr-agent.clearExtensionSecrets",
         "title": "PR Agent: Clear Extension Secrets"
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -55,6 +55,52 @@ export async function getLatestNumbers(
   );
 }
 
+export async function getAssociatedPulls(
+  token: string,
+  owner: string,
+  repository: string,
+  branch: string,
+): Promise<{
+  repository: {
+    ref: {
+      associatedPullRequests: {
+        nodes: {
+          number: number;
+          state: 'OPEN' | 'CLOSED';
+          title: string;
+          url: string;
+        }[];
+      };
+    };
+  };
+} | null> {
+  return doRequest(
+    {
+      // Note: qualifiedName matching falls back to simple name if qualified not found
+      query: `query AssociatedPulls($owner:String!, $name:String!, $branch:String!){
+        repository(owner: $owner, name: $name) {
+          ref(qualifiedName: $branch) {
+            associatedPullRequests(first: 10, states: OPEN) {
+              nodes {
+                title
+                url
+                number
+                state
+              }
+            }
+          }
+        }
+      }`,
+      variables: {
+        branch,
+        owner,
+        name: repository,
+      },
+    },
+    token,
+  );
+}
+
 async function doRequest(body: {
   query: string,
   variables: Record<string, string>,

--- a/src/git.ts
+++ b/src/git.ts
@@ -9,7 +9,12 @@ export function isGitRepository(dir: string): boolean {
   return false;
 }
 
-export function parseRemoteUrl(remoteUrl: string): { owner: string, name: string } | null {
+export type GitRemote = {
+  owner: string;
+  name: string;
+};
+
+export function parseRemoteUrl(remoteUrl: string): GitRemote | null {
   let [owner, name] = remoteUrl.split(':')[1].split('/');
   name = name.replace('.git', '');
 
@@ -19,11 +24,22 @@ export function parseRemoteUrl(remoteUrl: string): { owner: string, name: string
   return { owner, name };
 }
 
+export type GitConfig = {
+  [key: `branch "${string}"`]: {
+    merge: string;
+  };
+  [key: `remote "${string}"`]: {
+    url: string;
+  };
+};
+
+export type GitConfigBranch = GitConfig['branch "branch-name"'];
+export type GitConfigRemote = GitConfig['remote "remote-name"'];
+
 export function parseGitConfig(dir: string) {
   return ini.parse(fs.readFileSync(path.join(dir, '.git', 'config'), 'utf-8'));
 }
 
-// TODO: config type
-export function getRemotes(config: any) {
+export function getRemotes(config: GitConfig) {
   return Object.keys(config).filter(key => key.startsWith('remote '));
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -24,22 +24,25 @@ export function parseRemoteUrl(remoteUrl: string): GitRemote | null {
   return { owner, name };
 }
 
+export type GitConfigBranchKey = `branch "${string}"`;
+export type GitConfigRemoteKey = `remote "${string}"`;
+
 export type GitConfig = {
-  [key: `branch "${string}"`]: {
+  [key: GitConfigBranchKey]: {
     merge: string;
   };
-  [key: `remote "${string}"`]: {
+  [key: GitConfigRemoteKey]: {
     url: string;
   };
 };
 
-export type GitConfigBranch = GitConfig['branch "branch-name"'];
-export type GitConfigRemote = GitConfig['remote "remote-name"'];
+export type GitConfigBranch = GitConfig[GitConfigBranchKey];
+export type GitConfigRemote = GitConfig[GitConfigRemoteKey];
 
 export function parseGitConfig(dir: string) {
   return ini.parse(fs.readFileSync(path.join(dir, '.git', 'config'), 'utf-8'));
 }
 
-export function getRemotes(config: GitConfig) {
-  return Object.keys(config).filter(key => key.startsWith('remote '));
+export function getRemotes(config: GitConfig): GitConfigRemoteKey[] {
+  return Object.keys(config).filter(key => key.startsWith('remote ')) as GitConfigRemoteKey[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,5 @@
+export type Value<V> = {
+  value: V;
+} | {
+  errorMessage: string;
+};


### PR DESCRIPTION
This PR refactors large part of the extension to make in easier to add more pull number types.

This PR adds `current` PR number type.

The new command adds the current PR number for the given remote branch if at least one PR is open. If multiple PRs are opened associated with the current branch a quick select will let the user choose the PR.

--- 

Currently only `refs/heads` prefix is supported.